### PR TITLE
Fix for install error: "Invalid comparison operator in dependency: >="

### DIFF
--- a/casesolver_1.4.1/DESCRIPTION
+++ b/casesolver_1.4.1/DESCRIPTION
@@ -7,6 +7,7 @@ Author: Oyvind Bleka
 Maintainer: Oyvind Bleka <oyvble@hotmail.com>
 Description: CaseSolver is a software which automatically compares DNA profiles within a selected case.
 License: GPL(>=2)
+Depends: euroformix (>= 2.0.2)
 Imports:
     gWidgets2tcltk, R2HTML, igraph, forensim, euroformix 
 Suggests:

--- a/casesolver_1.4.1/DESCRIPTION
+++ b/casesolver_1.4.1/DESCRIPTION
@@ -8,7 +8,7 @@ Maintainer: Oyvind Bleka <oyvble@hotmail.com>
 Description: CaseSolver is a software which automatically compares DNA profiles within a selected case.
 License: GPL(>=2)
 Imports:
-    gWidgets2tcltk, R2HTML, igraph, forensim, euroformix(>= 2.0.2) 
+    gWidgets2tcltk, R2HTML, igraph, forensim, euroformix 
 Suggests:
     bigmemory
 RoxygenNote: 6.1.1


### PR DESCRIPTION
Hi,

I couldn't install casesolver due to the above error. I made some changes to the DESCRIPTION file to fix it and it now installs fine.
Best,

Chris